### PR TITLE
Fix psychic hammer synergies only applying to minimum damage

### DIFF
--- a/data/skills/PD2/assassin.js
+++ b/data/skills/PD2/assassin.js
@@ -25,7 +25,7 @@ var character_pd2_assassin = {class_name:"Assassin", strength:20, dexterity:20, 
 		if (skill.name == "Dragon Claw" && elem == 0) { 				result += (6*skills[9].level) }
 		if (skill.name == "Dragon Tail" && elem == 0) { 				result += (10*skills[1].level) }
 		
-		if (skill.name == "Psychic Hammer" && elem > 0 && elem < 2) {	result *= (1 + 0.18*skills[17].level + 0.18*skills[14].level + 0.18*skills[16].level) }
+		if (skill.name == "Psychic Hammer" && elem > 0 && elem < 3) {	result *= (1 + 0.18*skills[17].level + 0.18*skills[14].level + 0.18*skills[16].level) }
 		if (skill.name == "Mind Blast" && elem == 0) { 					result = 2 - 2*Math.ceil((skill.level-1)/20) }
 		if (skill.name == "Mind Blast" && elem == 1) { 					result = ~~skill.data.values[elem][skill.level] + 2.6-2.6*Math.min(1,skill.level) }
 		if (skill.name == "Mind Blast" && elem > 1 && elem < 4) { 		result *= (1 + 0.12*skills[10].level + 0.12*skills[14].level + 0.12*skills[16].level) }


### PR DESCRIPTION
I noticed PD2 psychic hammer synergies weren't applying to its maximum damage, just its minimum damage, so I fixed that.